### PR TITLE
Split the furious/calamitous lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,25 +64,18 @@
 				<span class="marginnote">
 					Approximate sort order:<br/>
 						<a href="https://en.wikipedia.org/wiki/Schadenfreude">Schadenfreude</a>,<br/>
-						mildly concerning,<br/>
-						genuinely concerning,<br/>
-						physically harmful,<br/>
-						<a href="http://knowyourmeme.com/memes/cthulhu">Cthulhu</a> awakens from the depths.
+						mildly emotional,<br/>
+						genuinely emotional
 				</span>
 				increasing order of rage:
 			</p>
 			<ol class="">
 				<li>ludicrous: laughable in a pleasant way, funny</li>
-				<li>a circus: complex, laughable, smelling vaguely of animals</li>
 				<li>absurd: irrational, foolish, in defiance of truth and common sense</li>
 				<li>incredible: not worthy of belief &mdash; too extraordinary and improbable</li>
-				<li>careless: negligent, unconcerned, inattentive, unmindful</li>
 				<li>farcical: low-quality humor, pageantry, parade without meaning</li>
 				<li>ridiculous: deserving of laughter because of its absurdity</li>
-				<li>preposterous: maladapted to its purposes, foolish, unreasonably absurd</li>
-				<li>bleak: cold, colorless, cheerless</li>
 				<li>unbelievable: simply not credible</li>
-				<li>reckless: rash and negligent, inattentive</li>
 				<li>terrible: exciting terror and dread, formidable</li>
 				<li>squicky: causing repulsion when you encounter it</li>
 				<li>abhorrent: causing horror when you encounter it</li>
@@ -90,15 +83,40 @@
 				<li>reprehensible: worthy of blame and disapproval</li>
 				<li>atrocious: heinous and wicked</li>
 				<li>baleful: full of deadly and pernicious influence, portending evil</li>
-				<li>ruinous: causing or tending to cause destruction</li>
-				<li>baneful: poisonous and likely to cause death</li>
-				<li>deadly: going to cause someone(s) to die</li>
 				<li>pernicious: deadly, destructive, and mischevious</li>
-				<li>a calamity: an event or disaster which produces extensive evil</li>
 				<li>incomprehensible: beyond human understanding, literally</li>
 			</ol>
 			<p>If you find yourself using these words, <a href="http://philome.la/jace_harr/you-feel-like-shit-an-interactive-self-care-guide/play">"You Feel Like Shit: An Interactive Self Care Guide"</a> may be helpful.</p>
 			<p>If you have words you wish to contribute, please <a href="https://github.com/benlk/ranked-situational-fury/issues">create a Github ticket</a> or <a href="https://twitter.com/benlkeith">tweet at the maintainer</a>. Suggestions are very welcome.</p>
+		</section>
+
+		<section class="bg-red">
+			<h2 id="calamitous-list">Calamitous words</h2>
+			<p> Use these words to describe the situation's physical effect.</p>
+			<p>
+				In roughly
+				<label for="sort-danger-order" class="margin-toggle"><u>*</u></label>
+				<input type="checkbox" id="sort-danger-order" class="margin-toggle" />
+				<span class="marginnote">
+					Approximate sort order:<br/>
+						funny,<br/>
+						physically harmful,<br/>
+						<a href="http://knowyourmeme.com/memes/cthulhu">Cthulhu</a> awakens from the depths.
+				</span>
+				increasing order of danger:
+			</p>
+			<ol class="">
+				<li>a circus: complex, laughable, smelling vaguely of animals</li>
+				<li>careless: negligent, unconcerned, inattentive, unmindful</li>
+				<li>preposterous: maladapted to its purposes, foolish, unreasonably absurd</li>
+				<li>bleak: cold, colorless, cheerless</li>
+				<li>reckless: rash and negligent, inattentive</li>
+				<li>ruinous: causing or tending to cause destruction</li>
+				<li>baneful: poisonous and likely to cause death</li>
+				<li>deadly: going to cause someone(s) to die</li>
+				<li>a calamity: an event or disaster which produces extensive evil</li>
+				<li>incomprehensible: beyond human understanding, literally</li>
+			</ol>
 		</section>
 
 		<section>


### PR DESCRIPTION
This implements #16, splitting the list of words into two:

- words that describe how the speaker feels about the situation
- words that describe the situation

It also cleans up the stylesheet to remove the `text-decoration-skip: ink` shim.

Still to do:

- [ ] ~~find more words~~
- [ ] side-by-side display of lists at larger screen sizes